### PR TITLE
Ensure that at least one test actually runs.

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -3,13 +3,9 @@ use warnings;
 
 use Test::More;
 
-BEGIN {
-    if (! $ENV{PI_BOARD}){
-        plan skip_all => "not a Pi board";
-        exit;
-    }
+SKIP: {
+    skip "not a Pi board", 1 unless $ENV{PI_BOARD};
+    use_ok('WiringPi::API');
 }
-
-BEGIN { use_ok('WiringPi::API') };
 
 done_testing();


### PR DESCRIPTION
If the wiringPi library is actually installed, then we can, at the very least,
test that we can import the module even if we're not on a Pi board.

Ensure that one test runs in that situation.